### PR TITLE
CI/CD: Add commit linting and auto docs publishing

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -61,6 +61,35 @@ jobs:
             **/build/reports/detekt/
           retention-days: 7
 
+  commit-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Lint PR title (conventional commit)
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            docs
+            chore
+            ci
+            refactor
+            perf
+            test
+            build
+            style
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" must not start with an uppercase letter.
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -2,6 +2,8 @@ name: Publish Documentation to GitHub Pages
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request introduces improvements to the project's GitHub Actions workflows. The main changes add a new commit linting job to enforce conventional commit message standards on pull requests, and update the documentation publishing workflow to trigger on new releases.

**CI/CD Workflow Enhancements:**

* Added a `commit-lint` job to `.github/workflows/pr-checks.yml` that uses `amannn/action-semantic-pull-request` to enforce conventional commit message standards on pull requests, ensuring better commit hygiene and consistency.

* Updated `.github/workflows/publish-docs.yml` to trigger the documentation publishing workflow not only manually (`workflow_dispatch`) but also automatically whenever a new release is published, improving automation and documentation availability.