### PR TITLE
Add Dokka configuration for module documentation

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/burkido/convention/PublishConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/burkido/convention/PublishConventionPlugin.kt
@@ -9,6 +9,8 @@ import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.get
+import org.jetbrains.dokka.gradle.DokkaExtension
+import java.net.URI
 
 
 class PublishConventionPlugin : Plugin<Project> {
@@ -17,6 +19,19 @@ class PublishConventionPlugin : Plugin<Project> {
         with(pluginManager) {
             apply("maven-publish")
             apply("org.jetbrains.dokka")
+        }
+
+        // AGP 9.x bundles Kotlin support and blocks applying org.jetbrains.kotlin.android,
+        // so Dokka cannot auto-discover source sets via KGP. Register them manually instead.
+        extensions.configure<DokkaExtension> {
+            dokkaSourceSets.register("main") {
+                sourceRoots.from(file("src/main/java"), file("src/main/kotlin"))
+                sourceLink {
+                    localDirectory.set(project.file("src/main/java"))
+                    remoteUrl.set(URI("https://github.com/burkido/auto-read-otp/tree/main/${project.name}/src/main/java"))
+                    remoteLineSuffix.set("#L")
+                }
+            }
         }
 
         extensions.configure<LibraryExtension> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
     alias(libs.plugins.dokka)
 }
 
+dokka {
+    moduleName.set("VerificationCodeReader")
+}
+
 // Aggregate Dokka documentation from library subprojects
 dependencies {
     dokka(project(":sms-reader"))

--- a/otp-input-kit/build.gradle.kts
+++ b/otp-input-kit/build.gradle.kts
@@ -2,11 +2,15 @@ plugins {
     id("burkido.android.library")
     id("burkido.android.compose")
     id("burkido.android.publish")
-    //id("burkido.detekt")
+    id("burkido.detekt")
 }
 
 android {
     namespace = "com.burkido.otpinputkit"
+}
+
+dokka {
+    moduleName.set("OTP Input Kit")
 }
 
 libraryPublish {

--- a/sms-reader/build.gradle.kts
+++ b/sms-reader/build.gradle.kts
@@ -9,6 +9,10 @@ android {
     namespace = "com.burkido.autoreadotp"
 }
 
+dokka {
+    moduleName.set("SMS Reader")
+}
+
 libraryPublish {
     artifactId.set("auto-read-otp")
 }


### PR DESCRIPTION
This pull request introduces improvements to documentation generation and code quality enforcement for the `otp-input-kit` and `sms-reader` modules, as well as enhancements to the Dokka configuration in the publishing convention plugin. The main changes are grouped into documentation enhancements and code quality tooling.

**Documentation enhancements:**

* Added Dokka configuration blocks to both `otp-input-kit/build.gradle.kts` and `sms-reader/build.gradle.kts`, setting the `moduleName` for each module to improve generated documentation. [[1]](diffhunk://#diff-6f16f895c5396d0a41c3408b99ffeb18dd400d9f7a667a7cd9b0fd69e270d373L5-R15) [[2]](diffhunk://#diff-72a9569ec08cdfdce9b95c0f00cea05997e3e90f93175df26a6b628b2d18df86R12-R15)
* Updated the `PublishConventionPlugin` to manually register Dokka source sets and source links, addressing AGP 9.x compatibility and ensuring proper documentation generation when Kotlin source sets cannot be auto-discovered. [[1]](diffhunk://#diff-bc00d295bba185655278ff77874fb1a636a7482e6bdc8819cd4867368f7b2513R12-R13) [[2]](diffhunk://#diff-bc00d295bba185655278ff77874fb1a636a7482e6bdc8819cd4867368f7b2513R24-R36)

**Code quality tooling:**

* Enabled the `burkido.detekt` plugin in `otp-input-kit/build.gradle.kts` to enforce static code analysis and maintain code quality.