### PR TITLE
Refactor otp-input-kit structure and add CountdownTimer feature

### DIFF
--- a/app/src/main/java/com/burkido/verificationcodereader/VerificationScreen.kt
+++ b/app/src/main/java/com/burkido/verificationcodereader/VerificationScreen.kt
@@ -18,7 +18,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.burkido.autoreadotp.SmsUserConsent
-import com.burkido.otpinputkit.fillOtp
+import com.burkido.otpinputkit.countdowntimer.CountdownTimer
+import com.burkido.otpinputkit.countdowntimer.CountdownTimerDefaults
+import com.burkido.otpinputkit.countdowntimer.rememberCountdownTimerState
+import com.burkido.otpinputkit.entry.fillOtp
 import com.burkido.verificationcodereader.sample.CompactOtpSample
 import com.burkido.verificationcodereader.sample.DefaultOtpSample
 import com.burkido.verificationcodereader.sample.MidnightOtpSample
@@ -28,6 +31,9 @@ import com.burkido.verificationcodereader.sample.UnderlineOtpSample
 
 @Composable
 fun VerificationScreen() {
+    val timerState = rememberCountdownTimerState(
+        endDate = System.currentTimeMillis() + java.util.concurrent.TimeUnit.MINUTES.toMillis(TIMER_MINUTES)
+    )
     val defaultState = rememberTextFieldState()
     val outlinedState = rememberTextFieldState()
     val underlineState = rememberTextFieldState()
@@ -45,6 +51,19 @@ fun VerificationScreen() {
         Text(
             text = "OTP Design Examples",
             style = MaterialTheme.typography.headlineSmall,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Code expires in:",
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        CountdownTimer(
+            state = timerState,
+            size = CountdownTimerDefaults.size(),
+            onTimerFinish = { Log.d(TAG, "Countdown finished") },
         )
 
         Spacer(modifier = Modifier.height(32.dp))
@@ -105,3 +124,4 @@ private fun VerificationScreenPreview() {
 
 private const val OTP_LENGTH = 6
 private const val TAG = "VerificationScreen"
+private const val TIMER_MINUTES = 5L

--- a/app/src/main/java/com/burkido/verificationcodereader/sample/CompactOtpSample.kt
+++ b/app/src/main/java/com/burkido/verificationcodereader/sample/CompactOtpSample.kt
@@ -11,10 +11,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.burkido.otpinputkit.OtpInputDefaults
-import com.burkido.otpinputkit.OtpInputField
-import com.burkido.otpinputkit.cell.DefaultOtpCell
-import com.burkido.otpinputkit.style.OtpCursorConfig
+import com.burkido.otpinputkit.entry.OtpInputDefaults
+import com.burkido.otpinputkit.entry.OtpInputField
+import com.burkido.otpinputkit.entry.cell.DefaultOtpCell
+import com.burkido.otpinputkit.entry.style.OtpCursorConfig
 
 private val CompactColors
     @Composable get() = OtpInputDefaults.colors(

--- a/app/src/main/java/com/burkido/verificationcodereader/sample/CountdownTimerSamples.kt
+++ b/app/src/main/java/com/burkido/verificationcodereader/sample/CountdownTimerSamples.kt
@@ -1,0 +1,138 @@
+package com.burkido.verificationcodereader.sample
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.burkido.otpinputkit.countdowntimer.CountdownTimer
+import com.burkido.otpinputkit.countdowntimer.CountdownTimerDefaults
+import com.burkido.otpinputkit.countdowntimer.rememberCountdownTimerState
+import java.util.concurrent.TimeUnit
+
+private val SAMPLE_DURATION_MS = TimeUnit.MINUTES.toMillis(30L)
+
+/**
+ * Default countdown timer — pure Material3 theme with no overrides.
+ */
+@Composable
+fun DefaultTimerSample() {
+    val endDate = remember { System.currentTimeMillis() + SAMPLE_DURATION_MS }
+    val state = rememberCountdownTimerState(endDate = endDate)
+    Text("Default", style = MaterialTheme.typography.titleMedium)
+    Spacer(modifier = Modifier.height(12.dp))
+    CountdownTimer(state = state)
+}
+
+/**
+ * Danger timer — large red boxes signalling urgency (e.g. code about to expire).
+ */
+@Composable
+fun DangerTimerSample() {
+    val endDate = remember { System.currentTimeMillis() + SAMPLE_DURATION_MS }
+    val state = rememberCountdownTimerState(endDate = endDate)
+    Text("Danger", style = MaterialTheme.typography.titleMedium)
+    Spacer(modifier = Modifier.height(12.dp))
+    CountdownTimer(
+        state = state,
+        style = CountdownTimerDefaults.style(
+            backgroundColor = Color(0xFFFFEBEE),
+            textStyle = MaterialTheme.typography.labelLarge.copy(
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFFD32F2F),
+            ),
+            separatorColor = Color(0xFFD32F2F),
+        ),
+        size = CountdownTimerDefaults.size(
+            textSize = 16.sp,
+            verticalPadding = 6.dp,
+            horizontalPadding = 10.dp,
+        ),
+    )
+}
+
+/**
+ * Midnight timer — dark navy background with a cyan accent,
+ * matching the Midnight OTP design.
+ */
+@Composable
+fun MidnightTimerSample() {
+    val endDate = remember { System.currentTimeMillis() + SAMPLE_DURATION_MS }
+    val state = rememberCountdownTimerState(endDate = endDate)
+    Text("Midnight", style = MaterialTheme.typography.titleMedium)
+    Spacer(modifier = Modifier.height(12.dp))
+    CountdownTimer(
+        state = state,
+        style = CountdownTimerDefaults.style(
+            backgroundColor = Color(0xFF16213E),
+            textStyle = MaterialTheme.typography.labelLarge.copy(
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF00D4FF),
+            ),
+            separatorColor = Color(0xFF00D4FF),
+        ),
+    )
+}
+
+/**
+ * Amber timer — warm orange palette (small/compact size),
+ * matching the Pill OTP design.
+ */
+@Composable
+fun AmberTimerSample() {
+    val endDate = remember { System.currentTimeMillis() + SAMPLE_DURATION_MS }
+    val state = rememberCountdownTimerState(endDate = endDate)
+    Text("Amber", style = MaterialTheme.typography.titleMedium)
+    Spacer(modifier = Modifier.height(12.dp))
+    CountdownTimer(
+        state = state,
+        style = CountdownTimerDefaults.style(
+            backgroundColor = Color(0xFFFFF3E0),
+            textStyle = MaterialTheme.typography.labelLarge.copy(
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFFFF6F00),
+            ),
+            separatorColor = Color(0xFFFF6F00),
+        ),
+        size = CountdownTimerDefaults.size(
+            textSize = 12.sp,
+            verticalPadding = 1.dp,
+            horizontalPadding = 5.dp,
+        ),
+    )
+}
+
+/**
+ * Violet timer — purple boxes with extra spacing,
+ * matching the Compact/violet OTP design.
+ */
+@Composable
+fun VioletTimerSample() {
+    val endDate = remember { System.currentTimeMillis() + SAMPLE_DURATION_MS }
+    val state = rememberCountdownTimerState(endDate = endDate)
+    Text("Violet", style = MaterialTheme.typography.titleMedium)
+    Spacer(modifier = Modifier.height(12.dp))
+    CountdownTimer(
+        state = state,
+        style = CountdownTimerDefaults.style(
+            backgroundColor = Color(0xFFEDE7F6),
+            textStyle = MaterialTheme.typography.labelLarge.copy(
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF7C4DFF),
+            ),
+            separatorColor = Color(0xFF7C4DFF),
+        ),
+        size = CountdownTimerDefaults.size(
+            textSize = 14.sp,
+            verticalPadding = 4.dp,
+            horizontalPadding = 8.dp,
+            boxSpacing = 2.dp,
+        ),
+    )
+}

--- a/app/src/main/java/com/burkido/verificationcodereader/sample/DefaultOtpSample.kt
+++ b/app/src/main/java/com/burkido/verificationcodereader/sample/DefaultOtpSample.kt
@@ -8,7 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.burkido.otpinputkit.OtpInputField
+import com.burkido.otpinputkit.entry.OtpInputField
 
 /**
  * Default OTP input — rounded box cells with Material3 theming.

--- a/app/src/main/java/com/burkido/verificationcodereader/sample/MidnightOtpSample.kt
+++ b/app/src/main/java/com/burkido/verificationcodereader/sample/MidnightOtpSample.kt
@@ -9,11 +9,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.burkido.otpinputkit.OtpInputDefaults
-import com.burkido.otpinputkit.OtpInputField
-import com.burkido.otpinputkit.cell.DefaultOtpCell
-import com.burkido.otpinputkit.style.CellAnimation
-import com.burkido.otpinputkit.style.OtpCursorConfig
+import com.burkido.otpinputkit.entry.OtpInputDefaults
+import com.burkido.otpinputkit.entry.OtpInputField
+import com.burkido.otpinputkit.entry.cell.DefaultOtpCell
+import com.burkido.otpinputkit.entry.style.CellAnimation
+import com.burkido.otpinputkit.entry.style.OtpCursorConfig
 
 private val MidnightColors
     @Composable get() = OtpInputDefaults.colors(

--- a/app/src/main/java/com/burkido/verificationcodereader/sample/OutlinedOtpSample.kt
+++ b/app/src/main/java/com/burkido/verificationcodereader/sample/OutlinedOtpSample.kt
@@ -8,8 +8,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.burkido.otpinputkit.OtpInputField
-import com.burkido.otpinputkit.cell.OutlinedOtpCell
+import com.burkido.otpinputkit.entry.OtpInputField
+import com.burkido.otpinputkit.entry.cell.OutlinedOtpCell
 
 /**
  * Outlined OTP input — circular cells with transparent backgrounds.

--- a/app/src/main/java/com/burkido/verificationcodereader/sample/PillOtpSample.kt
+++ b/app/src/main/java/com/burkido/verificationcodereader/sample/PillOtpSample.kt
@@ -9,11 +9,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.burkido.otpinputkit.OtpInputDefaults
-import com.burkido.otpinputkit.OtpInputField
-import com.burkido.otpinputkit.cell.DefaultOtpCell
-import com.burkido.otpinputkit.style.CellAnimation
-import com.burkido.otpinputkit.style.OtpCursorConfig
+import com.burkido.otpinputkit.entry.OtpInputDefaults
+import com.burkido.otpinputkit.entry.OtpInputField
+import com.burkido.otpinputkit.entry.cell.DefaultOtpCell
+import com.burkido.otpinputkit.entry.style.CellAnimation
+import com.burkido.otpinputkit.entry.style.OtpCursorConfig
 
 private val PillColors
     @Composable get() = OtpInputDefaults.colors(

--- a/app/src/main/java/com/burkido/verificationcodereader/sample/UnderlineOtpSample.kt
+++ b/app/src/main/java/com/burkido/verificationcodereader/sample/UnderlineOtpSample.kt
@@ -8,8 +8,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.burkido.otpinputkit.OtpInputField
-import com.burkido.otpinputkit.cell.UnderlineOtpCell
+import com.burkido.otpinputkit.entry.OtpInputField
+import com.burkido.otpinputkit.entry.cell.UnderlineOtpCell
 
 /**
  * Underline OTP input — iOS-style digit above an animated bottom line, no border box.

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/CountdownTimer.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/CountdownTimer.kt
@@ -1,0 +1,134 @@
+package com.burkido.otpinputkit.countdowntimer
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.burkido.otpinputkit.countdowntimer.style.CountdownTimerSize
+import com.burkido.otpinputkit.countdowntimer.style.CountdownTimerStyle
+import com.burkido.otpinputkit.countdowntimer.style.CountdownTimerTokens
+import java.util.concurrent.TimeUnit
+
+/**
+ * Displays a countdown timer as `HH : MM : SS` time boxes.
+ *
+ * The composable manages the timer lifecycle automatically: it starts the clock
+ * when first composed and cancels it when removed from the composition.
+ * The entire row hides itself when the timer finishes.
+ *
+ * ### Basic usage
+ * ```kotlin
+ * val state = rememberCountdownTimerState(
+ *     endDate = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5)
+ * )
+ *
+ * CountdownTimer(state = state)
+ * ```
+ *
+ * ### Custom style
+ * ```kotlin
+ * CountdownTimer(
+ *     state = state,
+ *     style = CountdownTimerDefaults.style(
+ *         backgroundColor = MaterialTheme.colorScheme.errorContainer
+ *     ),
+ *     size = CountdownTimerSize.Large,
+ *     onTimerFinish = { /* resend button becomes enabled */ }
+ * )
+ * ```
+ *
+ * @param state A [CountdownTimerState] created via [rememberCountdownTimerState].
+ * @param modifier Modifier for the root [Row].
+ * @param style Visual configuration. Defaults to [CountdownTimerDefaults.style].
+ * @param size Size/padding configuration. Defaults to [CountdownTimerDefaults.size] ([CountdownTimerSize.Medium]).
+ * @param backgroundAlpha Alpha multiplier for the time-box backgrounds (0f–1f).
+ * @param onTimerFinish Called once when the countdown reaches zero.
+ */
+@Composable
+fun CountdownTimer(
+    state: CountdownTimerState,
+    modifier: Modifier = Modifier,
+    style: CountdownTimerStyle = CountdownTimerDefaults.style(),
+    size: CountdownTimerSize = CountdownTimerDefaults.size(),
+    backgroundAlpha: Float = 1f,
+    onTimerFinish: () -> Unit = {},
+) {
+    val latestOnTimerFinish by rememberUpdatedState(onTimerFinish)
+
+    DisposableEffect(state) {
+        state.setOnTimerFinishListener { latestOnTimerFinish() }
+        state.startTimer()
+        onDispose { state.cancelTimer() }
+    }
+
+    if (state.isFinished) return
+
+    val remainingTimes by remember(state) {
+        derivedStateOf { state.getRemainingTimes(state.remainingTime) }
+    }
+    val (hours, minutes, seconds) = remainingTimes
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TimeBoxItem(time = hours, style = style, size = size, backgroundAlpha = backgroundAlpha)
+        Spacer(modifier = Modifier.width(size.boxSpacing))
+        Separator(style = style)
+        Spacer(modifier = Modifier.width(size.boxSpacing))
+        TimeBoxItem(time = minutes, style = style, size = size, backgroundAlpha = backgroundAlpha)
+        Spacer(modifier = Modifier.width(size.boxSpacing))
+        Separator(style = style)
+        Spacer(modifier = Modifier.width(size.boxSpacing))
+        TimeBoxItem(time = seconds, style = style, size = size, backgroundAlpha = backgroundAlpha)
+    }
+}
+
+@Composable
+private fun Separator(style: CountdownTimerStyle) {
+    Text(
+        text = ":",
+        style = style.textStyle.copy(color = style.separatorColor),
+        modifier = Modifier.width(CountdownTimerTokens.SeparatorHorizontalPadding * 2),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CountdownTimerLargePreview() {
+    val state = rememberCountdownTimerState(
+        endDate = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(PREVIEW_DURATION),
+    )
+    CountdownTimer(state = state, size = CountdownTimerDefaults.size(textSize = 16.sp, verticalPadding = 6.dp, horizontalPadding = 8.dp))
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CountdownTimerMediumPreview() {
+    val state = rememberCountdownTimerState(
+        endDate = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(PREVIEW_DURATION),
+    )
+    CountdownTimer(state = state)
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CountdownTimerSmallPreview() {
+    val state = rememberCountdownTimerState(
+        endDate = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(PREVIEW_DURATION),
+    )
+    CountdownTimer(state = state, size = CountdownTimerDefaults.size(textSize = 12.sp, verticalPadding = 1.dp, horizontalPadding = 5.dp))
+}
+
+private const val PREVIEW_DURATION = 3672L // 1h 1m 12s

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/CountdownTimerDefaults.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/CountdownTimerDefaults.kt
@@ -1,0 +1,86 @@
+package com.burkido.otpinputkit.countdowntimer
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import com.burkido.otpinputkit.countdowntimer.style.CountdownTimerSize
+import com.burkido.otpinputkit.countdowntimer.style.CountdownTimerStyle
+import com.burkido.otpinputkit.countdowntimer.style.CountdownTimerTokens
+
+/**
+ * Contains default values and factory functions for [CountdownTimer].
+ *
+ * Follows the Material3 `*Defaults` pattern (e.g. `ButtonDefaults`).
+ * Override only the values you need while keeping sensible defaults:
+ *
+ * ```kotlin
+ * CountdownTimerDefaults.style(
+ *     backgroundColor = Color.Red.copy(alpha = 0.1f)
+ * )
+ * ```
+ */
+object CountdownTimerDefaults {
+
+    /**
+     * Creates a [CountdownTimerStyle] with Material3-derived defaults.
+     *
+     * @param backgroundColor Background color of each time box.
+     *   Defaults to [MaterialTheme.colorScheme.primaryContainer].
+     * @param textStyle Text style applied to time-unit values.
+     *   Defaults to a bold variant of [MaterialTheme.typography.labelLarge]
+     *   at the given [textSize].
+     * @param textSize Font size override for the time-unit text.
+     *   Ignored when [textStyle] is provided explicitly.
+     * @param separatorColor Color of the colon `:` separators.
+     *   Defaults to [MaterialTheme.colorScheme.onSurface].
+     */
+    @Composable
+    fun style(
+        backgroundColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.primaryContainer,
+        textStyle: TextStyle = MaterialTheme.typography.labelLarge.copy(
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+        ),
+        textSize: TextUnit = TextUnit.Unspecified,
+        separatorColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurface,
+    ): CountdownTimerStyle {
+        val resolvedTextStyle = if (textSize != TextUnit.Unspecified) {
+            textStyle.copy(fontSize = textSize)
+        } else {
+            textStyle
+        }
+        return CountdownTimerStyle(
+            backgroundColor = backgroundColor,
+            textStyle = resolvedTextStyle,
+            separatorColor = separatorColor,
+        )
+    }
+
+    /**
+     * Creates a [CountdownTimerSize] with sensible defaults.
+     *
+     * Override only the values you need:
+     * ```kotlin
+     * CountdownTimerDefaults.size(textSize = 18.sp)
+     * ```
+     *
+     * @param verticalPadding Vertical padding inside each time box.
+     * @param horizontalPadding Horizontal padding inside each time box.
+     * @param boxSpacing Space between a time box and its adjacent colon separator.
+     * @param textSize Font size of the time-unit text.
+     */
+    fun size(
+        verticalPadding: Dp = CountdownTimerTokens.VerticalPadding,
+        horizontalPadding: Dp = CountdownTimerTokens.HorizontalPadding,
+        boxSpacing: Dp = CountdownTimerTokens.BoxSpacing,
+        textSize: TextUnit = CountdownTimerTokens.TextSize,
+    ): CountdownTimerSize = CountdownTimerSize(
+        verticalPadding = verticalPadding,
+        horizontalPadding = horizontalPadding,
+        boxSpacing = boxSpacing,
+        textSize = textSize,
+    )
+}

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/CountdownTimerState.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/CountdownTimerState.kt
@@ -1,0 +1,114 @@
+package com.burkido.otpinputkit.countdowntimer
+
+import android.os.CountDownTimer
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import java.util.concurrent.TimeUnit
+
+/**
+ * State holder for [CountdownTimer] that owns the underlying [CountDownTimer] lifecycle.
+ *
+ * Create instances via [rememberCountdownTimerState] so the state survives
+ * configuration changes through [rememberSaveable].
+ *
+ * @param endDate The countdown target time in milliseconds since epoch
+ *   (e.g. `System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5)`).
+ *
+ * @property remainingTime Remaining milliseconds. Updates every second and triggers
+ *   recomposition automatically.
+ * @property isFinished `true` once the timer reaches zero.
+ */
+@Stable
+class CountdownTimerState(val endDate: Long) {
+
+    private var onTimerFinish: () -> Unit = {}
+
+    private val countDownTimer: CountDownTimer by lazy { createCountDownTimer() }
+
+    var remainingTime: Long by mutableLongStateOf(
+        (endDate - System.currentTimeMillis()).coerceAtLeast(0L)
+    )
+        private set
+
+    var isFinished: Boolean by mutableStateOf(endDate <= 0L || endDate <= System.currentTimeMillis())
+        private set
+
+    /** Starts the countdown. If [endDate] is already in the past the timer finishes immediately. */
+    fun startTimer() {
+        if (endDate <= 0L || endDate <= System.currentTimeMillis()) {
+            remainingTime = 0L
+            isFinished = true
+            onTimerFinish()
+            return
+        }
+        countDownTimer.start()
+    }
+
+    /** Cancels the countdown without triggering [onTimerFinish]. */
+    fun cancelTimer() {
+        countDownTimer.cancel()
+    }
+
+    /**
+     * Registers a callback that fires once when the timer reaches zero.
+     * Call this before [startTimer]. Replacing the listener does not restart the timer.
+     */
+    fun setOnTimerFinishListener(action: () -> Unit) {
+        onTimerFinish = action
+    }
+
+    /**
+     * Converts [time] (milliseconds) into a [Triple] of `(hours, minutes, seconds)`.
+     */
+    fun getRemainingTimes(time: Long): Triple<Long, Long, Long> {
+        val totalSeconds = time / ONE_SECOND_MS
+        val hours = totalSeconds / ONE_HOUR_SECONDS
+        val minutes = (totalSeconds % ONE_HOUR_SECONDS) / ONE_MINUTE_SECONDS
+        val seconds = totalSeconds % ONE_MINUTE_SECONDS
+        return Triple(hours, minutes, seconds)
+    }
+
+    private fun createCountDownTimer(): CountDownTimer =
+        object : CountDownTimer(endDate - System.currentTimeMillis(), TICK_INTERVAL) {
+            override fun onTick(millisUntilFinished: Long) {
+                remainingTime = (endDate - System.currentTimeMillis()).coerceAtLeast(0L)
+            }
+
+            override fun onFinish() {
+                remainingTime = 0L
+                isFinished = true
+                onTimerFinish()
+            }
+        }
+
+    companion object {
+        private val TICK_INTERVAL = TimeUnit.SECONDS.toMillis(1)
+        private const val ONE_HOUR_SECONDS = 3600L
+        private const val ONE_MINUTE_SECONDS = 60L
+        private const val ONE_SECOND_MS = 1000L
+
+        internal val Saver = listSaver(
+            save = { listOf(it.endDate) },
+            restore = { CountdownTimerState(endDate = it[0] as Long) },
+        )
+    }
+}
+
+/**
+ * Creates and remembers a [CountdownTimerState] that survives configuration changes.
+ *
+ * The state is keyed on [endDate] — changing it creates a new timer.
+ *
+ * @param endDate The countdown target time in milliseconds since epoch.
+ */
+@Composable
+fun rememberCountdownTimerState(endDate: Long): CountdownTimerState =
+    rememberSaveable(endDate, saver = CountdownTimerState.Saver) {
+        CountdownTimerState(endDate = endDate)
+    }

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/TimeBoxItem.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/TimeBoxItem.kt
@@ -1,0 +1,47 @@
+package com.burkido.otpinputkit.countdowntimer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.burkido.otpinputkit.countdowntimer.style.CountdownTimerSize
+import com.burkido.otpinputkit.countdowntimer.style.CountdownTimerStyle
+import com.burkido.otpinputkit.countdowntimer.style.CountdownTimerTokens
+
+/**
+ * Renders a single time unit (hours, minutes, or seconds) as a styled rounded box.
+ *
+ * @param time The numeric value to display (e.g. 5 → "05").
+ * @param style Visual configuration.
+ * @param size Size/padding configuration.
+ * @param backgroundAlpha Alpha multiplier for the box background. Defaults to `1f`.
+ */
+@Composable
+internal fun TimeBoxItem(
+    time: Long,
+    style: CountdownTimerStyle,
+    size: CountdownTimerSize,
+    modifier: Modifier = Modifier,
+    backgroundAlpha: Float = 1f,
+) {
+    Text(
+        text = String.format(TIME_FORMAT, time),
+        style = style.textStyle.copy(fontSize = size.textSize),
+        maxLines = 1,
+        modifier = modifier
+            .wrapContentSize()
+            .background(
+                color = style.backgroundColor.copy(alpha = backgroundAlpha),
+                shape = RoundedCornerShape(CountdownTimerTokens.BoxCornerRadius),
+            )
+            .padding(
+                horizontal = size.horizontalPadding,
+                vertical = size.verticalPadding,
+            ),
+    )
+}
+
+private const val TIME_FORMAT = "%02d"

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/style/CountdownTimerSize.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/style/CountdownTimerSize.kt
@@ -1,0 +1,26 @@
+package com.burkido.otpinputkit.countdowntimer.style
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+
+/**
+ * Size configuration for [com.burkido.otpinputkit.countdowntimer.CountdownTimer].
+ *
+ * Create instances via [com.burkido.otpinputkit.countdowntimer.CountdownTimerDefaults.size],
+ * overriding only the values you need:
+ *
+ * ```kotlin
+ * CountdownTimerDefaults.size(textSize = 18.sp)
+ * ```
+ *
+ * @param verticalPadding Vertical padding inside each time box.
+ * @param horizontalPadding Horizontal padding inside each time box.
+ * @param boxSpacing Space between a time box and its adjacent colon separator.
+ * @param textSize Font size of the time-unit text.
+ */
+data class CountdownTimerSize(
+    val verticalPadding: Dp,
+    val horizontalPadding: Dp,
+    val boxSpacing: Dp,
+    val textSize: TextUnit,
+)

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/style/CountdownTimerStyle.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/style/CountdownTimerStyle.kt
@@ -1,0 +1,21 @@
+package com.burkido.otpinputkit.countdowntimer.style
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+
+/**
+ * Visual styling for [com.burkido.otpinputkit.countdowntimer.CountdownTimer].
+ *
+ * Create instances via [com.burkido.otpinputkit.countdowntimer.CountdownTimerDefaults.style].
+ *
+ * @param backgroundColor Background color of each time box.
+ * @param textStyle Text style applied to each time-unit value (hours, minutes, seconds).
+ * @param separatorColor Color of the colon `:` separators between boxes.
+ */
+@Immutable
+data class CountdownTimerStyle(
+    val backgroundColor: Color,
+    val textStyle: TextStyle,
+    val separatorColor: Color,
+)

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/style/CountdownTimerTokens.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/countdowntimer/style/CountdownTimerTokens.kt
@@ -1,0 +1,25 @@
+package com.burkido.otpinputkit.countdowntimer.style
+
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Single source of truth for all primitive default values used in the countdown timer.
+ *
+ * Follows the Material3 `*Tokens` pattern. These values are internal and not part
+ * of the public API — consumers customise via [com.burkido.otpinputkit.countdowntimer.CountdownTimerDefaults].
+ */
+internal object CountdownTimerTokens {
+
+    // ── Box dimensions ─────────────────────────────────────────────────────
+    val TextSize = 14.sp
+    val VerticalPadding = 2.dp
+    val HorizontalPadding = 4.dp
+    val BoxSpacing = 1.dp
+
+    // ── Shape ──────────────────────────────────────────────────────────────
+    val BoxCornerRadius = 4.dp
+
+    // ── Separator ──────────────────────────────────────────────────────────
+    val SeparatorHorizontalPadding = 2.dp
+}

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/OtpInputDefaults.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/OtpInputDefaults.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit
+package com.burkido.otpinputkit.entry
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -9,15 +9,15 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
-import com.burkido.otpinputkit.style.CellAnimation
-import com.burkido.otpinputkit.style.OtpAnimationSpec
-import com.burkido.otpinputkit.style.OtpCellColors
-import com.burkido.otpinputkit.style.OtpCellDimensions
-import com.burkido.otpinputkit.style.OtpCellPadding
-import com.burkido.otpinputkit.style.OtpCursorConfig
-import com.burkido.otpinputkit.style.OtpMaskConfig
-import com.burkido.otpinputkit.style.OtpTextStyles
-import com.burkido.otpinputkit.style.OtpTokens
+import com.burkido.otpinputkit.entry.style.CellAnimation
+import com.burkido.otpinputkit.entry.style.OtpAnimationSpec
+import com.burkido.otpinputkit.entry.style.OtpCellColors
+import com.burkido.otpinputkit.entry.style.OtpCellDimensions
+import com.burkido.otpinputkit.entry.style.OtpCellPadding
+import com.burkido.otpinputkit.entry.style.OtpCursorConfig
+import com.burkido.otpinputkit.entry.style.OtpMaskConfig
+import com.burkido.otpinputkit.entry.style.OtpTextStyles
+import com.burkido.otpinputkit.entry.style.OtpTokens
 
 /**
  * Contains default values and factory functions for OTP input components.

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/OtpInputField.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/OtpInputField.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit
+package com.burkido.otpinputkit.entry
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -27,14 +27,14 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.input.KeyboardType
-import com.burkido.otpinputkit.cell.DefaultOtpCell
-import com.burkido.otpinputkit.style.OtpAnimationSpec
-import com.burkido.otpinputkit.style.OtpCellColors
-import com.burkido.otpinputkit.style.OtpCellDimensions
-import com.burkido.otpinputkit.style.OtpCellPadding
-import com.burkido.otpinputkit.style.OtpCursorConfig
-import com.burkido.otpinputkit.style.OtpMaskConfig
-import com.burkido.otpinputkit.style.OtpTextStyles
+import com.burkido.otpinputkit.entry.cell.DefaultOtpCell
+import com.burkido.otpinputkit.entry.style.OtpAnimationSpec
+import com.burkido.otpinputkit.entry.style.OtpCellColors
+import com.burkido.otpinputkit.entry.style.OtpCellDimensions
+import com.burkido.otpinputkit.entry.style.OtpCellPadding
+import com.burkido.otpinputkit.entry.style.OtpCursorConfig
+import com.burkido.otpinputkit.entry.style.OtpMaskConfig
+import com.burkido.otpinputkit.entry.style.OtpTextStyles
 import kotlinx.coroutines.flow.collectLatest
 
 // ────────────────────────────────────────────────────────────────────

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/OtpInputState.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/OtpInputState.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit
+package com.burkido.otpinputkit.entry
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/OtpInputTransformation.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/OtpInputTransformation.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit
+package com.burkido.otpinputkit.entry
 
 import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.TextFieldBuffer

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/OtpTextFieldStateExtensions.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/OtpTextFieldStateExtensions.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit
+package com.burkido.otpinputkit.entry
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/cell/CursorIndicator.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/cell/CursorIndicator.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit.cell
+package com.burkido.otpinputkit.entry.cell
 
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -14,7 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import com.burkido.otpinputkit.style.OtpCursorConfig
+import com.burkido.otpinputkit.entry.style.OtpCursorConfig
 
 /**
  * Internal blinking cursor indicator for focused OTP cells.

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/cell/DefaultOtpCell.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/cell/DefaultOtpCell.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit.cell
+package com.burkido.otpinputkit.entry.cell
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.EnterTransition
@@ -31,15 +31,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
-import com.burkido.otpinputkit.OtpInputDefaults
-import com.burkido.otpinputkit.style.CellAnimation
-import com.burkido.otpinputkit.style.OtpAnimationSpec
-import com.burkido.otpinputkit.style.OtpCellColors
-import com.burkido.otpinputkit.style.OtpCellDimensions
-import com.burkido.otpinputkit.style.OtpCellPadding
-import com.burkido.otpinputkit.style.OtpCursorConfig
-import com.burkido.otpinputkit.style.OtpMaskConfig
-import com.burkido.otpinputkit.style.OtpTextStyles
+import com.burkido.otpinputkit.entry.OtpInputDefaults
+import com.burkido.otpinputkit.entry.style.CellAnimation
+import com.burkido.otpinputkit.entry.style.OtpAnimationSpec
+import com.burkido.otpinputkit.entry.style.OtpCellColors
+import com.burkido.otpinputkit.entry.style.OtpCellDimensions
+import com.burkido.otpinputkit.entry.style.OtpCellPadding
+import com.burkido.otpinputkit.entry.style.OtpCursorConfig
+import com.burkido.otpinputkit.entry.style.OtpMaskConfig
+import com.burkido.otpinputkit.entry.style.OtpTextStyles
 import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/cell/OutlinedOtpCell.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/cell/OutlinedOtpCell.kt
@@ -1,18 +1,18 @@
-package com.burkido.otpinputkit.cell
+package com.burkido.otpinputkit.entry.cell
 
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
-import com.burkido.otpinputkit.OtpInputDefaults
-import com.burkido.otpinputkit.style.OtpAnimationSpec
-import com.burkido.otpinputkit.style.OtpCellColors
-import com.burkido.otpinputkit.style.OtpCellDimensions
-import com.burkido.otpinputkit.style.OtpCellPadding
-import com.burkido.otpinputkit.style.OtpCursorConfig
-import com.burkido.otpinputkit.style.OtpMaskConfig
-import com.burkido.otpinputkit.style.OtpTextStyles
+import com.burkido.otpinputkit.entry.OtpInputDefaults
+import com.burkido.otpinputkit.entry.style.OtpAnimationSpec
+import com.burkido.otpinputkit.entry.style.OtpCellColors
+import com.burkido.otpinputkit.entry.style.OtpCellDimensions
+import com.burkido.otpinputkit.entry.style.OtpCellPadding
+import com.burkido.otpinputkit.entry.style.OtpCursorConfig
+import com.burkido.otpinputkit.entry.style.OtpMaskConfig
+import com.burkido.otpinputkit.entry.style.OtpTextStyles
 
 /**
  * Outlined (circle / pill) OTP cell with transparent background.

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/cell/UnderlineOtpCell.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/cell/UnderlineOtpCell.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit.cell
+package com.burkido.otpinputkit.entry.cell
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.EnterTransition
@@ -31,15 +31,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import com.burkido.otpinputkit.OtpInputDefaults
-import com.burkido.otpinputkit.style.CellAnimation
-import com.burkido.otpinputkit.style.OtpAnimationSpec
-import com.burkido.otpinputkit.style.OtpCellColors
-import com.burkido.otpinputkit.style.OtpCellDimensions
-import com.burkido.otpinputkit.style.OtpCellPadding
-import com.burkido.otpinputkit.style.OtpCursorConfig
-import com.burkido.otpinputkit.style.OtpMaskConfig
-import com.burkido.otpinputkit.style.OtpTextStyles
+import com.burkido.otpinputkit.entry.OtpInputDefaults
+import com.burkido.otpinputkit.entry.style.CellAnimation
+import com.burkido.otpinputkit.entry.style.OtpAnimationSpec
+import com.burkido.otpinputkit.entry.style.OtpCellColors
+import com.burkido.otpinputkit.entry.style.OtpCellDimensions
+import com.burkido.otpinputkit.entry.style.OtpCellPadding
+import com.burkido.otpinputkit.entry.style.OtpCursorConfig
+import com.burkido.otpinputkit.entry.style.OtpMaskConfig
+import com.burkido.otpinputkit.entry.style.OtpTextStyles
 import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpAnimationSpec.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpAnimationSpec.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit.style
+package com.burkido.otpinputkit.entry.style
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.Dp

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpCellColors.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpCellColors.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit.style
+package com.burkido.otpinputkit.entry.style
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpCellDimensions.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpCellDimensions.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit.style
+package com.burkido.otpinputkit.entry.style
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.Dp

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpCellPadding.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpCellPadding.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit.style
+package com.burkido.otpinputkit.entry.style
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.Dp

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpCursorConfig.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpCursorConfig.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit.style
+package com.burkido.otpinputkit.entry.style
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpMaskConfig.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpMaskConfig.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit.style
+package com.burkido.otpinputkit.entry.style
 
 import androidx.compose.runtime.Immutable
 

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpTextStyles.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpTextStyles.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit.style
+package com.burkido.otpinputkit.entry.style
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.text.TextStyle

--- a/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpTokens.kt
+++ b/otp-input-kit/src/main/java/com/burkido/otpinputkit/entry/style/OtpTokens.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit.style
+package com.burkido.otpinputkit.entry.style
 
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp

--- a/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/OtpInputDefaultsTest.kt
+++ b/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/OtpInputDefaultsTest.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit
+package com.burkido.otpinputkit.entry
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test

--- a/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/OtpInputFieldStateTest.kt
+++ b/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/OtpInputFieldStateTest.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit
+package com.burkido.otpinputkit.entry
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before

--- a/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/OtpInputStateTest.kt
+++ b/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/OtpInputStateTest.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit
+package com.burkido.otpinputkit.entry
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before

--- a/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/OtpInputTransformationTest.kt
+++ b/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/OtpInputTransformationTest.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit
+package com.burkido.otpinputkit.entry
 
 import androidx.compose.foundation.text.input.TextFieldState
 import com.google.common.truth.Truth.assertThat

--- a/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/OtpTextFieldStateExtensionsTest.kt
+++ b/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/OtpTextFieldStateExtensionsTest.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit
+package com.burkido.otpinputkit.entry
 
 import androidx.compose.foundation.text.input.TextFieldState
 import com.google.common.truth.Truth.assertThat

--- a/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/style/OtpAnimationSpecTest.kt
+++ b/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/style/OtpAnimationSpecTest.kt
@@ -1,6 +1,6 @@
-package com.burkido.otpinputkit.style
+package com.burkido.otpinputkit.entry.style
 
-import com.burkido.otpinputkit.OtpInputDefaults
+import com.burkido.otpinputkit.entry.OtpInputDefaults
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 

--- a/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/style/OtpCellColorsTest.kt
+++ b/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/style/OtpCellColorsTest.kt
@@ -1,4 +1,4 @@
-package com.burkido.otpinputkit.style
+package com.burkido.otpinputkit.entry.style
 
 import androidx.compose.ui.graphics.Color
 import com.google.common.truth.Truth.assertThat

--- a/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/style/OtpCellDimensionsTest.kt
+++ b/otp-input-kit/src/test/java/com/burkido/otpinputkit/entry/style/OtpCellDimensionsTest.kt
@@ -1,6 +1,6 @@
-package com.burkido.otpinputkit.style
+package com.burkido.otpinputkit.entry.style
 
-import com.burkido.otpinputkit.OtpInputDefaults
+import com.burkido.otpinputkit.entry.OtpInputDefaults
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 


### PR DESCRIPTION
This pull request introduces a new customizable countdown timer component for the OTP input kit and integrates it into the `VerificationScreen`. It also reorganizes imports to reflect the new structure of the OTP input kit and adds sample usages for the countdown timer in various visual styles.

**Countdown Timer Feature:**

- Introduced a new `CountdownTimer` composable component in `otp-input-kit`, which displays a countdown as `HH : MM : SS` time boxes and manages its own lifecycle. The timer can be customized in terms of style, size, and behavior when the countdown finishes.
- Added `CountdownTimerDefaults` object to provide Material3-inspired default styles and sizing options for the timer, following the Compose `*Defaults` pattern.
- Integrated the countdown timer into `VerificationScreen`, showing a timer for code expiration and triggering a callback when the timer finishes. [[1]](diffhunk://#diff-83e605f3a07bbf573d3531d8e61a9fce2aaab34342389253b2d97b44f7d4ed14R34-R36) [[2]](diffhunk://#diff-83e605f3a07bbf573d3531d8e61a9fce2aaab34342389253b2d97b44f7d4ed14R56-R68) [[3]](diffhunk://#diff-83e605f3a07bbf573d3531d8e61a9fce2aaab34342389253b2d97b44f7d4ed14R127)

**Sample and Demo Enhancements:**

- Added a new sample file, `CountdownTimerSamples.kt`, demonstrating the countdown timer in various themes and configurations (default, danger, midnight, amber, violet) for easy reference and testing.

**Codebase Organization and Import Updates:**

- Updated imports throughout OTP sample files to reflect the new package structure, moving OTP input components under the `entry` subpackage and timer components under `countdowntimer`. [[1]](diffhunk://#diff-83e605f3a07bbf573d3531d8e61a9fce2aaab34342389253b2d97b44f7d4ed14L21-R24) [[2]](diffhunk://#diff-c9e1f1e3f24c3aed0a1f3dd59f1777b900acd3182a708b7a5bff0c0ea4b3d83fL14-R17) [[3]](diffhunk://#diff-a736738091ee694c539a1abf300ce9ba46354db97c8d61176f4d8af04daf073aL11-R11) [[4]](diffhunk://#diff-9cf82a53a30093f6dbded0773731f06fafef34fdd69e2e2401986e00884644d9L12-R16) [[5]](diffhunk://#diff-91bd11016d1deccddf29534081a0b631dfa54a3b44e43087ff29ca342c772298L11-R12) [[6]](diffhunk://#diff-d187a08e44b9fbbef6982757774f7a44790df9f2bd3c5c858571e13e7ed9b540L12-R16) [[7]](diffhunk://#diff-a10061278e9299775e3416f4766994df45c176f48abbd36925c2e14daeb2054eL11-R12)